### PR TITLE
bugfix: 'delete semester' button in /exreg/create now works properly …

### DIFF
--- a/src/main/resources/static/js/exregMapModules.js
+++ b/src/main/resources/static/js/exregMapModules.js
@@ -135,7 +135,7 @@ function addNewSemester() {
                  * Browser issue: When the span character is clicked in Chrome: Event target is a span
                  * In Firefox it is the button.
                  */
-                var idToDelete = delBtnSemesterId[event.target.id || $(event.target).parent().attr('id')];
+                var idToDelete = delBtnSemesterId[event.target.id || $(event.target).parent().attr('id') || $(event.target).parent().parent().attr('id')];
                 var semesterToDelete = listOfSemester[idToDelete];
                 var lastSemester = $("#semesterContainer").children(":last");
                 var modules = {};


### PR DESCRIPTION
…in chrome

before: clicking directly on the trash can icon of a semester in the Map Modules tab did nothing
after: clicking the trashcan button wherever deletes the semester