### PR TITLE
fixed show button, re-added edit button

### DIFF
--- a/src/main/resources/templates/moduleList.html
+++ b/src/main/resources/templates/moduleList.html
@@ -56,18 +56,27 @@
         <div class="col-md-2 my-1" th:unless="${module.exReg}!=null">-</div>
         <div class="col-md-4 my-1" th:text="${module.title}"></div>
         <div class="col-md-3 my-1" th:text="${module.moduleCoordinator}"></div>
-        <div class="col-md-1 text-center">
-            <a class="btn btn-success text-white py-0 px-2" role="button" th:href="'/exreg/syllabus?id=17#module' + ${module.id}">
-                <i class="fa fa-eye"></i>
-            </a>
+        <div class="col-md-1">
+            <div class="row">
+                <th:block sec:authorize="hasRole('[ADMIN]')">
+                    <div class="col-4 text-center">
+                        <a class="btn btn-info text-white py-0 px-2"
+                            role="button"
+                            th:href="@{/module/edit?id=} + |${module.id}|">
+                            <i class="fas fa-pencil-alt"></i>
+                        </a>
+                    </div>
+                </th:block>
+                <div class="col-4 text-center">
+                    <a th:if="${module.exReg}"
+                        class="btn btn-success text-white py-0 px-2"
+                        role="button"
+                        th:href="'/exreg/syllabus?id=' + ${module.exReg.id} + '#module' + ${module.id}">
+                        <i class="fa fa-eye"></i>
+                    </a>
+                </div>
+            </div>
         </div>
-
-        <!--   --------ADMIN FUNCTIONALITY--------  -->
-<!--        <div class="col-md-1 text-center">-->
-<!--            <a class="btn btn-info text-white py-0 px-2" role="button" th:href="@{/module/edit?id=} + |${module.id}|">-->
-<!--                <i class="fas fa-pencil-alt"></i>-->
-<!--            </a>-->
-<!--        </div>-->
     </div>
 </div>
 </body>


### PR DESCRIPTION
Hello,
I fixed an issue on the module list page. The eye button always redirects to an exReg with the id 17 even though the module isn't mapped to this exReg. I also re-added the edit button, but it seems that pull-request #52 does this too - so thats a potential merge conflict

Greetings